### PR TITLE
Add CP437 roundtrip test

### DIFF
--- a/src/cp437.rs
+++ b/src/cp437.rs
@@ -3,7 +3,6 @@
 /// Converts a unicode character to a CP437 equivalent, returning 0 if it didn't have a match
 pub fn to_byte(c: char) -> u8 {
     match c {
-        '\0' => 0,
         '☺' => 1,
         '☻' => 2,
         '♥' => 3,

--- a/src/cp437.rs
+++ b/src/cp437.rs
@@ -280,6 +280,8 @@ pub fn to_byte(c: char) -> u8 {
 
 #[must_use]
 #[allow(clippy::too_many_lines)]
+/// Converts a CP437 byte to its Unicode character equivalent.
+/// All 256 byte values are explicitly mapped.
 pub fn to_char(c: u8) -> char {
     match c {
         0 => '\0',

--- a/src/cp437.rs
+++ b/src/cp437.rs
@@ -281,7 +281,7 @@ pub fn to_byte(c: char) -> u8 {
 #[must_use]
 #[allow(clippy::too_many_lines)]
 /// Converts a CP437 byte to its Unicode character equivalent.
-/// All 256 byte values are explicitly mapped.
+/// All 256 byte values are mapped to a Unicode character.
 pub fn to_char(c: u8) -> char {
     match c {
         0 => '\0',

--- a/src/cp437.rs
+++ b/src/cp437.rs
@@ -3,6 +3,7 @@
 /// Converts a unicode character to a CP437 equivalent, returning 0 if it didn't have a match
 pub fn to_byte(c: char) -> u8 {
     match c {
+        '\0' => 0,
         '☺' => 1,
         '☻' => 2,
         '♥' => 3,
@@ -272,6 +273,7 @@ pub fn to_byte(c: char) -> u8 {
         'ⁿ' => 252,
         '²' => 253,
         '■' => 254,
+        '\u{a0}' => 255,
 
         _ => 0,
     }
@@ -281,6 +283,7 @@ pub fn to_byte(c: char) -> u8 {
 #[allow(clippy::too_many_lines)]
 pub fn to_char(c: u8) -> char {
     match c {
+        0 => '\0',
         1 => '☺',
         2 => '☻',
         3 => '♥',
@@ -550,6 +553,7 @@ pub fn to_char(c: u8) -> char {
         252 => 'ⁿ',
         253 => '²',
         254 => '■',
+        255 => '\u{a0}',
 
         _ => ' ',
     }
@@ -594,6 +598,13 @@ mod tests {
         ];
         for (ch, i) in test.into_iter().zip(test2.into_iter()) {
             assert_eq!(to_char(ch), i);
+        }
+    }
+
+    #[test]
+    fn roundtrip_all() {
+        for b in 0u8..=255 {
+            assert_eq!(super::to_byte(super::to_char(b)), b);
         }
     }
 }


### PR DESCRIPTION
## Summary
- map NUL and NBSP in the CP437 helpers
- add a roundtrip test that covers every byte

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_6840336872c483319556467e28549252